### PR TITLE
Revamp admin CMS with media library and site text controls

### DIFF
--- a/app/admin/media/page.jsx
+++ b/app/admin/media/page.jsx
@@ -1,0 +1,162 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+function FileCard({ file, onDelete, onSaveMeta }) {
+  const [title, setTitle] = useState(file.title || '');
+  const [alt, setAlt] = useState(file.alt || '');
+  const [tags, setTags] = useState((file.tags || []).join(', '));
+  const isImage = file.type?.startsWith('image/');
+  const isVideo = file.type?.startsWith('video/');
+  const isAudio = file.type?.startsWith('audio/');
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(file.url);
+      // naive toast
+      alert('Copied URL');
+    } catch (e) {
+      console.warn('clipboard failed', e);
+    }
+  };
+
+  const handleSave = () => {
+    const cleanTags = tags
+      .split(',')
+      .map((t) => t.trim())
+      .filter(Boolean);
+    onSaveMeta(file.pathname, { title, alt, tags: cleanTags });
+  };
+
+  return (
+    <div className="entry-ledger__item">
+      <div className="entry-ledger__icon">
+        <span className="icon" aria-hidden>
+          {isImage ? '🖼️' : isVideo ? '🎞️' : isAudio ? '🎵' : '📄'}
+        </span>
+      </div>
+      <div className="entry-ledger__body">
+        <div className="entry-ledger__meta">
+          <span className="entry-ledger__meta-item">{file.type || 'unknown'}</span>
+          <span className="entry-ledger__meta-item">{(file.size / 1024).toFixed(0)} KB</span>
+          <a href={file.url} target="_blank" rel="noreferrer" className="entry-ledger__meta-item">
+            Open
+          </a>
+        </div>
+        {isImage ? (
+          <img src={file.url} alt="preview" style={{ maxWidth: 220, borderRadius: 8 }} />
+        ) : null}
+        <div className="admin-field-row">
+          <div className="admin-field">
+            <label>Title</label>
+            <input value={title} onChange={(e) => setTitle(e.target.value)} />
+          </div>
+          <div className="admin-field">
+            <label>Alt</label>
+            <input value={alt} onChange={(e) => setAlt(e.target.value)} />
+          </div>
+          <div className="admin-field">
+            <label>Tags</label>
+            <input value={tags} onChange={(e) => setTags(e.target.value)} />
+          </div>
+        </div>
+        <div className="admin-actions">
+          <div className="admin-actions__buttons">
+            <button type="button" className="admin-ghost" onClick={handleCopy}>
+              Copy URL
+            </button>
+            <button type="button" className="admin-primary" onClick={handleSave}>
+              Save Meta
+            </button>
+            <button type="button" className="admin-danger" onClick={() => onDelete(file.pathname)}>
+              Delete
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function MediaLibraryPage() {
+  const [files, setFiles] = useState([]);
+  const [q, setQ] = useState('');
+  const [status, setStatus] = useState('');
+
+  const refresh = useCallback(async () => {
+    try {
+      setStatus('');
+      const res = await fetch('/api/media', { cache: 'no-store' });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data?.error || 'Failed to load');
+      setFiles(Array.isArray(data.files) ? data.files : []);
+    } catch (e) {
+      setStatus(e.message);
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const filtered = useMemo(() => {
+    const needle = q.trim().toLowerCase();
+    if (!needle) return files;
+    return files.filter((f) =>
+      [f.url, f.title, f.alt, (f.tags || []).join(',')].join(' ').toLowerCase().includes(needle)
+    );
+  }, [files, q]);
+
+  const handleDelete = useCallback(async (pathname) => {
+    if (!confirm('Delete this file?')) return;
+    try {
+      const res = await fetch(`/api/media?pathname=${encodeURIComponent(pathname)}`, { method: 'DELETE' });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data?.error || 'Delete failed');
+      setFiles((prev) => prev.filter((f) => f.pathname !== pathname));
+    } catch (e) {
+      setStatus(e.message);
+    }
+  }, []);
+
+  const handleSaveMeta = useCallback(async (pathname, patch) => {
+    try {
+      const res = await fetch('/api/media', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ pathname, ...patch })
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data?.error || 'Update failed');
+      setFiles((prev) => prev.map((f) => (f.pathname === pathname ? { ...f, ...patch } : f)));
+    } catch (e) {
+      setStatus(e.message);
+    }
+  }, []);
+
+  return (
+    <div className="admin-shell">
+      <header className="admin-shell__header">
+        <div>
+          <h1>Media Library</h1>
+          <p>Browse, reuse, and manage uploaded assets.</p>
+        </div>
+        <div className="admin-field" style={{ minWidth: 280 }}>
+          <label htmlFor="search">Search</label>
+          <input id="search" value={q} onChange={(e) => setQ(e.target.value)} placeholder="title, tag, url…" />
+        </div>
+      </header>
+      <section className="section-screen">
+        {status && <p className="admin-status admin-status--error">{status}</p>}
+        <ul className="entry-ledger">
+          {filtered.map((file) => (
+            <li key={file.pathname}>
+              <FileCard file={file} onDelete={handleDelete} onSaveMeta={handleSaveMeta} />
+            </li>
+          ))}
+          {!filtered.length && <p className="section-empty">No files yet</p>}
+        </ul>
+      </section>
+    </div>
+  );
+}

--- a/app/admin/settings/field/page.jsx
+++ b/app/admin/settings/field/page.jsx
@@ -1,0 +1,315 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { FIELD_DEFAULT_BASE, FIELD_DEFAULT_INFLUENCES } from '../../../../lib/fieldDefaults';
+
+const FIELD_BASE_CONTROLS = [
+  { id: 'amplitude', label: 'Amplitude', min: 30, max: 140, step: 1 },
+  { id: 'waveXFrequency', label: 'Frequency X', min: 0.05, max: 0.45, step: 0.005 },
+  { id: 'waveYFrequency', label: 'Frequency Y', min: 0.05, max: 0.45, step: 0.005 },
+  { id: 'swirlStrength', label: 'Swirl Strength', min: 0, max: 3, step: 0.01 },
+  { id: 'swirlFrequency', label: 'Swirl Scale', min: 0.001, max: 0.02, step: 0.0005 },
+  { id: 'animationSpeed', label: 'Flow Speed', min: 0.05, max: 1.2, step: 0.01 },
+  { id: 'pointSize', label: 'Point Scale', min: 6, max: 32, step: 0.5 },
+  { id: 'mouseInfluence', label: 'Pointer Warp', min: 0.001, max: 0.02, step: 0.0005 },
+  { id: 'rippleStrength', label: 'Ripple Strength', min: 10, max: 120, step: 1 },
+  { id: 'rippleSpeed', label: 'Ripple Speed', min: 120, max: 520, step: 5 },
+  { id: 'rippleWidth', label: 'Ripple Width', min: 8, max: 40, step: 0.1 },
+  { id: 'rippleDecay', label: 'Ripple Fade', min: 0.0005, max: 0.01, step: 0.0001 },
+  { id: 'opacity', label: 'Glow', min: 0.3, max: 1, step: 0.01 },
+  { id: 'brightness', label: 'Brightness', min: 0.1, max: 0.6, step: 0.01 },
+  { id: 'contrast', label: 'Contrast', min: 0.6, max: 2.5, step: 0.05 },
+  { id: 'fogDensity', label: 'Fog Density', min: 0.0002, max: 0.003, step: 0.0001 }
+];
+
+const FIELD_BOOLEAN_CONTROLS = [
+  { id: 'autoRotate', label: 'Auto Rotate' },
+  { id: 'showStats', label: 'Show Stats' }
+];
+
+const FIELD_INFLUENCE_GROUPS = [
+  {
+    id: 'about',
+    label: 'About Channel',
+    fields: [
+      { id: 'mouseInfluence', label: 'Pointer Warp', min: 0.001, max: 0.02, step: 0.0005 },
+      { id: 'animationSpeed', label: 'Flow Speed', min: 0.05, max: 1.2, step: 0.01 },
+      { id: 'brightness', label: 'Brightness', min: 0.1, max: 0.6, step: 0.01 }
+    ]
+  },
+  {
+    id: 'projects',
+    label: 'Projects Channel',
+    fields: [
+      { id: 'animationSpeed', label: 'Flow Speed', min: 0.05, max: 1.2, step: 0.01 },
+      { id: 'swirlStrength', label: 'Swirl Strength', min: 0, max: 3, step: 0.01 },
+      { id: 'pointSize', label: 'Point Scale', min: 6, max: 32, step: 0.5 }
+    ]
+  },
+  {
+    id: 'words',
+    label: 'Words Channel',
+    fields: [
+      { id: 'animationSpeed', label: 'Flow Speed', min: 0.05, max: 1.2, step: 0.01 },
+      { id: 'rippleWidth', label: 'Ripple Width', min: 8, max: 40, step: 0.1 },
+      { id: 'contrast', label: 'Contrast', min: 0.6, max: 2.5, step: 0.05 }
+    ]
+  },
+  {
+    id: 'sounds',
+    label: 'Sounds Channel',
+    fields: [
+      { id: 'rippleStrength', label: 'Ripple Strength', min: 10, max: 120, step: 1 },
+      { id: 'rippleDecay', label: 'Ripple Fade', min: 0.0005, max: 0.01, step: 0.0001 },
+      { id: 'mouseInfluence', label: 'Pointer Warp', min: 0.001, max: 0.02, step: 0.0005 }
+    ]
+  }
+];
+
+function buildDefaultFieldSettings() {
+  return {
+    base: { ...FIELD_DEFAULT_BASE },
+    influences: Object.keys(FIELD_DEFAULT_INFLUENCES).reduce((acc, key) => {
+      acc[key] = { ...FIELD_DEFAULT_INFLUENCES[key] };
+      return acc;
+    }, {})
+  };
+}
+
+export default function FieldSettingsPage() {
+  const [fieldSettings, setFieldSettings] = useState(null);
+  const [isSavingField, setIsSavingField] = useState(false);
+  const [fieldStatus, setFieldStatus] = useState('');
+
+  const hasFieldData = useMemo(() => Boolean(fieldSettings), [fieldSettings]);
+
+  const handleFieldBaseChange = useCallback((key, rawValue) => {
+    setFieldSettings((prev) => {
+      if (!prev || rawValue === '') return prev;
+      const numeric = Number(rawValue);
+      if (Number.isNaN(numeric)) return prev;
+      return {
+        ...prev,
+        base: {
+          ...prev.base,
+          [key]: numeric
+        }
+      };
+    });
+  }, []);
+
+  const handleFieldBooleanChange = useCallback((key, value) => {
+    setFieldSettings((prev) => {
+      if (!prev) return prev;
+      return {
+        ...prev,
+        base: {
+          ...prev.base,
+          [key]: value
+        }
+      };
+    });
+  }, []);
+
+  const handleFieldInfluenceChange = useCallback((section, key, rawValue) => {
+    setFieldSettings((prev) => {
+      if (!prev || rawValue === '') return prev;
+      const numeric = Number(rawValue);
+      if (Number.isNaN(numeric)) return prev;
+      return {
+        ...prev,
+        influences: {
+          ...prev.influences,
+          [section]: {
+            ...(prev.influences?.[section] ?? {}),
+            [key]: numeric
+          }
+        }
+      };
+    });
+  }, []);
+
+  const handleFieldReset = useCallback(() => {
+    setFieldSettings(buildDefaultFieldSettings());
+    setFieldStatus('Reset to defaults (unsaved)');
+  }, []);
+
+  const handleFieldSave = useCallback(async () => {
+    if (!fieldSettings) return;
+    try {
+      setIsSavingField(true);
+      setFieldStatus('');
+
+      const normalizedBase = Object.entries(FIELD_DEFAULT_BASE).reduce((acc, [key, defaultValue]) => {
+        const value = fieldSettings.base?.[key];
+        if (typeof defaultValue === 'boolean') {
+          acc[key] = typeof value === 'boolean' ? value : defaultValue;
+        } else {
+          acc[key] = typeof value === 'number' ? value : defaultValue;
+        }
+        return acc;
+      }, {});
+
+      const normalizedInfluences = Object.entries(FIELD_DEFAULT_INFLUENCES).reduce((acc, [section, defaults]) => {
+        const applied = fieldSettings.influences?.[section] ?? {};
+        acc[section] = Object.entries(defaults).reduce((inner, [key, defaultValue]) => {
+          const value = applied[key];
+          inner[key] = typeof value === 'number' ? value : defaultValue;
+          return inner;
+        }, {});
+        return acc;
+      }, {});
+
+      const response = await fetch('/api/field-settings', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ base: normalizedBase, influences: normalizedInfluences })
+      });
+      const result = await response.json();
+      if (!response.ok) {
+        throw new Error(result?.error || 'Failed to save field settings');
+      }
+
+      setFieldSettings({
+        base: { ...result.base },
+        influences: Object.keys(result.influences || {}).reduce((acc, key) => {
+          acc[key] = { ...result.influences[key] };
+          return acc;
+        }, {})
+      });
+      setFieldStatus('Saved');
+    } catch (error) {
+      console.error(error);
+      setFieldStatus(error.message);
+    } finally {
+      setIsSavingField(false);
+    }
+  }, [fieldSettings]);
+
+  useEffect(() => {
+    let ignore = false;
+    (async () => {
+      try {
+        const response = await fetch('/api/field-settings', { cache: 'no-store' });
+        const data = await response.json();
+        if (!response.ok) {
+          throw new Error(data?.error || 'Failed to load field settings');
+        }
+        if (!ignore) {
+          setFieldSettings({
+            base: { ...data.base },
+            influences: Object.keys(data.influences || {}).reduce((acc, key) => {
+              acc[key] = { ...data.influences[key] };
+              return acc;
+            }, {})
+          });
+          setFieldStatus('');
+        }
+      } catch (error) {
+        if (!ignore) {
+          console.error(error);
+          setFieldStatus(error.message);
+        }
+      }
+    })();
+
+    return () => {
+      ignore = true;
+    };
+  }, []);
+
+  return (
+    <div className="admin-shell">
+      <header className="admin-shell__header">
+        <div>
+          <h1>Field Settings</h1>
+          <p>Adjust the dotfield baseline and per-channel overrides.</p>
+        </div>
+      </header>
+      <section className="admin-editor-panel admin-editor-panel--field">
+        {!hasFieldData ? (
+          <p className="admin-loading">Loading field settings…</p>
+        ) : (
+          <div className="field-settings">
+            <section className="field-settings__section">
+              <header className="field-settings__header">
+                <h2>Base Field Mood</h2>
+                <p>These values load with every visit.</p>
+              </header>
+              <div className="field-settings__grid">
+                {FIELD_BASE_CONTROLS.map((control) => (
+                  <div key={control.id} className="admin-field field-settings__field">
+                    <label htmlFor={`field-base-${control.id}`}>{control.label}</label>
+                    <input
+                      id={`field-base-${control.id}`}
+                      type="number"
+                      min={control.min}
+                      max={control.max}
+                      step={control.step}
+                      value={fieldSettings.base?.[control.id] ?? ''}
+                      onChange={(event) => handleFieldBaseChange(control.id, event.target.value)}
+                    />
+                  </div>
+                ))}
+              </div>
+              <div className="field-settings__toggles">
+                {FIELD_BOOLEAN_CONTROLS.map((control) => (
+                  <label key={control.id} className="field-toggle">
+                    <input
+                      type="checkbox"
+                      checked={!!fieldSettings.base?.[control.id]}
+                      onChange={(event) => handleFieldBooleanChange(control.id, event.target.checked)}
+                    />
+                    <span>{control.label}</span>
+                  </label>
+                ))}
+              </div>
+            </section>
+
+            {FIELD_INFLUENCE_GROUPS.map((group) => (
+              <section key={group.id} className="field-settings__section">
+                <header className="field-settings__header">
+                  <h3>{group.label}</h3>
+                  <p>Overrides applied when visitors open this channel.</p>
+                </header>
+                <div className="field-settings__grid field-settings__grid--influence">
+                  {group.fields.map((control) => (
+                    <div key={`${group.id}-${control.id}`} className="admin-field field-settings__field">
+                      <label htmlFor={`field-${group.id}-${control.id}`}>{control.label}</label>
+                      <input
+                        id={`field-${group.id}-${control.id}`}
+                        type="number"
+                        min={control.min}
+                        max={control.max}
+                        step={control.step}
+                        value={fieldSettings.influences?.[group.id]?.[control.id] ?? ''}
+                        onChange={(event) => handleFieldInfluenceChange(group.id, control.id, event.target.value)}
+                      />
+                    </div>
+                  ))}
+                </div>
+              </section>
+            ))}
+
+            <div className="admin-actions field-settings__actions">
+              {fieldStatus && <span className="admin-status">{fieldStatus}</span>}
+              <div className="admin-actions__buttons">
+                <button type="button" className="admin-ghost" onClick={handleFieldReset}>
+                  Reset Defaults
+                </button>
+                <button
+                  type="button"
+                  className="admin-primary"
+                  onClick={handleFieldSave}
+                  disabled={isSavingField}
+                >
+                  {isSavingField ? 'Saving…' : 'Save Settings'}
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/app/admin/settings/site-text/page.jsx
+++ b/app/admin/settings/site-text/page.jsx
@@ -1,0 +1,135 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+export default function SiteTextSettingsPage() {
+  const [brand, setBrand] = useState('');
+  const [items, setItems] = useState([]);
+  const [status, setStatus] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    let ignore = false;
+    (async () => {
+      try {
+        const res = await fetch('/api/site-text', { cache: 'no-store' });
+        const data = await res.json();
+        if (!res.ok) throw new Error(data?.error || 'Failed to load');
+        if (ignore) return;
+        setBrand(data.brand || '');
+        setItems(Array.isArray(data.primaryMenu) ? data.primaryMenu : []);
+      } catch (e) {
+        if (!ignore) setStatus(e.message);
+      }
+    })();
+    return () => {
+      ignore = true;
+    };
+  }, []);
+
+  const setItem = useCallback((index, patch) => {
+    setItems((prev) => prev.map((it, i) => (i === index ? { ...it, ...patch } : it)));
+  }, []);
+
+  const moveItem = useCallback((index, dir) => {
+    setItems((prev) => {
+      const next = [...prev];
+      const j = index + dir;
+      if (j < 0 || j >= next.length) return prev;
+      const [it] = next.splice(index, 1);
+      next.splice(j, 0, it);
+      return next;
+    });
+  }, []);
+
+  const handleSave = useCallback(async () => {
+    try {
+      setSaving(true);
+      setStatus('');
+      const res = await fetch('/api/site-text', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ brand, primaryMenu: items })
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data?.error || 'Save failed');
+      setStatus('Saved');
+    } catch (e) {
+      setStatus(e.message);
+    } finally {
+      setSaving(false);
+    }
+  }, [brand, items]);
+
+  return (
+    <div className="admin-shell">
+      <header className="admin-shell__header">
+        <div>
+          <h1>Site Text</h1>
+          <p>Edit brand and primary menu text. Changes apply across the site.</p>
+        </div>
+      </header>
+      <section className="admin-editor-panel">
+        <div className="admin-field">
+          <label htmlFor="brand">Brand</label>
+          <input id="brand" value={brand} onChange={(e) => setBrand(e.target.value)} />
+        </div>
+        <div className="admin-field">
+          <label>Primary Menu</label>
+          <div className="field-settings__grid">
+            {items.map((item, index) => (
+              <div key={item.id || index} className="admin-field">
+                <div className="admin-field-row">
+                  <div className="admin-field">
+                    <label htmlFor={`label-${index}`}>Label</label>
+                    <input
+                      id={`label-${index}`}
+                      value={item.label || ''}
+                      onChange={(e) => setItem(index, { label: e.target.value })}
+                    />
+                  </div>
+                  <div className="admin-field">
+                    <label htmlFor={`route-${index}`}>Route</label>
+                    <input
+                      id={`route-${index}`}
+                      value={item.route || ''}
+                      onChange={(e) => setItem(index, { route: e.target.value })}
+                    />
+                  </div>
+                </div>
+                <div className="admin-field">
+                  <label htmlFor={`desc-${index}`}>Hover Description</label>
+                  <textarea
+                    id={`desc-${index}`}
+                    rows={2}
+                    value={item.description || ''}
+                    onChange={(e) => setItem(index, { description: e.target.value })}
+                  />
+                </div>
+                <div className="admin-actions">
+                  <span className="admin-status">{item.id}</span>
+                  <div className="admin-actions__buttons">
+                    <button type="button" className="admin-ghost" onClick={() => moveItem(index, -1)}>
+                      Move Up
+                    </button>
+                    <button type="button" className="admin-ghost" onClick={() => moveItem(index, 1)}>
+                      Move Down
+                    </button>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+        <div className="admin-actions">
+          {status && <span className="admin-status">{status}</span>}
+          <div className="admin-actions__buttons">
+            <button type="button" className="admin-primary" onClick={handleSave} disabled={saving}>
+              {saving ? 'Saving…' : 'Save'}
+            </button>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/api/content/[type]/duplicate/route.js
+++ b/app/api/content/[type]/duplicate/route.js
@@ -1,0 +1,53 @@
+import { NextResponse } from 'next/server';
+import { CONTENT_TYPES, readEntry, upsertEntry } from '../../../../../lib/contentStore';
+
+export const dynamic = 'force-dynamic';
+
+function isValidType(type) {
+  return CONTENT_TYPES.includes(type);
+}
+
+// no-op helper removed (lint)
+
+export async function POST(request, { params }) {
+  const { type } = params;
+  if (!isValidType(type)) {
+    return NextResponse.json({ error: 'Unsupported type' }, { status: 400 });
+  }
+
+  try {
+    const { slug } = await request.json();
+    if (!slug) {
+      return NextResponse.json({ error: 'Missing slug' }, { status: 400 });
+    }
+    const original = await readEntry(type, slug);
+    if (!original) {
+      return NextResponse.json({ error: 'Entry not found' }, { status: 404 });
+    }
+
+    const exists = async (s) => Boolean(await readEntry(type, s));
+    const copySlug = await (async () => {
+      let candidate = `${slug}-copy`;
+      let i = 2;
+      while (await exists(candidate)) {
+        candidate = `${slug}-copy-${i++}`;
+      }
+      return candidate;
+    })();
+
+    const now = new Date().toISOString();
+    const copy = {
+      ...original,
+      slug: copySlug,
+      title: `${original.title} (Copy)`,
+      status: 'draft',
+      updatedAt: now,
+      createdAt: now
+    };
+
+    await upsertEntry(type, copy);
+    return NextResponse.json({ entry: copy }, { status: 201 });
+  } catch (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}

--- a/app/api/content/[type]/route.js
+++ b/app/api/content/[type]/route.js
@@ -17,7 +17,16 @@ function normalizeEntry(payload) {
   if (!payload || typeof payload !== 'object') {
     return null;
   }
-  const { slug, title, summary = '', content = '', tags = [], createdAt = new Date().toISOString() } = payload;
+  const {
+    slug,
+    title,
+    summary = '',
+    content = '',
+    tags = [],
+    coverImage = null,
+    status = 'draft',
+    createdAt = new Date().toISOString()
+  } = payload;
   if (!slug || !title) {
     return null;
   }
@@ -27,7 +36,10 @@ function normalizeEntry(payload) {
     summary,
     content,
     tags,
-    createdAt
+    coverImage,
+    status: status === 'published' ? 'published' : 'draft',
+    createdAt,
+    updatedAt: new Date().toISOString()
   };
 }
 

--- a/app/api/media/route.js
+++ b/app/api/media/route.js
@@ -1,0 +1,47 @@
+import { NextResponse } from 'next/server';
+import { readMediaIndex, updateMediaFile, removeMediaFile } from '../../../lib/mediaIndex';
+import { del } from '@vercel/blob';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  try {
+    const { files } = await readMediaIndex();
+    return NextResponse.json({ files });
+  } catch (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}
+
+export async function PUT(request) {
+  try {
+    const { pathname, ...patch } = await request.json();
+    if (!pathname) return NextResponse.json({ error: 'Missing pathname' }, { status: 400 });
+    const updated = await updateMediaFile(pathname, patch);
+    if (!updated) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    return NextResponse.json({ file: updated });
+  } catch (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}
+
+export async function DELETE(request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const pathname = searchParams.get('pathname');
+    if (!pathname) return NextResponse.json({ error: 'Missing pathname' }, { status: 400 });
+
+    // Attempt blob deletion first (ignore not found)
+    try {
+      await del(pathname);
+    } catch (e) {
+      console.warn('[media] blob delete ignored', e?.message || e);
+    }
+
+    const { removed } = await removeMediaFile(pathname);
+    if (!removed) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}

--- a/app/api/site-text/route.js
+++ b/app/api/site-text/route.js
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server';
+import { readSiteText, writeSiteText } from '../../../lib/siteText';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  try {
+    const data = await readSiteText();
+    return NextResponse.json(data);
+  } catch (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}
+
+export async function PUT(request) {
+  try {
+    const payload = await request.json();
+    const saved = await writeSiteText(payload);
+    return NextResponse.json(saved);
+  } catch (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}

--- a/app/api/upload/route.js
+++ b/app/api/upload/route.js
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { put } from '@vercel/blob';
+import { appendMediaFile } from '../../../lib/mediaIndex';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
@@ -66,12 +67,20 @@ export async function POST(request) {
       cacheControl: 'public, max-age=31536000, immutable'
     });
 
-    return NextResponse.json({
+    const record = {
       url: blob.url,
       pathname: blob.pathname,
       size: blob.size,
       type: blob.contentType
-    });
+    };
+
+    try {
+      await appendMediaFile(record);
+    } catch (indexErr) {
+      console.warn('[upload] failed to append media index', indexErr);
+    }
+
+    return NextResponse.json(record);
   } catch (error) {
     console.error('[upload] error', error);
     return NextResponse.json({ error: error.message || 'Upload failed' }, { status: 500 });

--- a/app/globals.css
+++ b/app/globals.css
@@ -1893,6 +1893,19 @@ a {
   box-shadow: none;
   backdrop-filter: none;
   z-index: 8;
+  opacity: 0;
+  transform: translate(-50%, -18px);
+  pointer-events: none;
+  transition:
+    opacity 0.6s cubic-bezier(0.33, 1, 0.68, 1),
+    transform 0.6s cubic-bezier(0.33, 1, 0.68, 1);
+  will-change: opacity, transform;
+}
+
+.site-shell__header[data-nav-ready='true'] {
+  opacity: 1;
+  transform: translate(-50%, 0);
+  pointer-events: auto;
 }
 
 .site-shell--detail .site-shell__container {
@@ -1907,7 +1920,17 @@ a {
   text-decoration: none;
   font-family: 'IBM Plex Mono', 'Lucida Console', 'Courier New', monospace;
   color: var(--text-primary);
-  transition: color 0.2s ease;
+  opacity: 0;
+  transform: translateY(8px);
+  transition:
+    color 0.2s ease,
+    opacity 0.5s cubic-bezier(0.33, 1, 0.68, 1),
+    transform 0.5s cubic-bezier(0.33, 1, 0.68, 1);
+}
+
+.site-shell__header[data-nav-ready='true'] .site-shell__brand {
+  opacity: 1;
+  transform: translateY(0);
 }
 
 .site-shell__brand:hover,
@@ -1929,7 +1952,17 @@ a {
   text-transform: uppercase;
   text-decoration: none;
   color: var(--text-tertiary);
-  transition: color 0.2s ease;
+  opacity: 0;
+  transform: translateY(12px);
+  transition:
+    color 0.2s ease,
+    opacity 0.45s cubic-bezier(0.33, 1, 0.68, 1),
+    transform 0.45s cubic-bezier(0.33, 1, 0.68, 1);
+}
+
+.site-shell__header[data-nav-ready='true'] .site-shell__nav-link {
+  opacity: 1;
+  transform: translateY(0);
 }
 
 .site-shell__nav-link::after {
@@ -1968,8 +2001,18 @@ a {
   text-transform: uppercase;
   text-decoration: none;
   color: rgba(196, 232, 240, 0.8);
-  transition: color 0.2s ease;
+  opacity: 0;
+  transform: translateY(8px);
+  transition:
+    color 0.2s ease,
+    opacity 0.5s cubic-bezier(0.33, 1, 0.68, 1),
+    transform 0.5s cubic-bezier(0.33, 1, 0.68, 1);
   white-space: nowrap;
+}
+
+.site-shell__header[data-nav-ready='true'] .site-shell__social {
+  opacity: 1;
+  transform: translateY(0);
 }
 
 .site-shell__social:hover,
@@ -2000,6 +2043,26 @@ a {
   to {
     opacity: 1;
     transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :root {
+    --nav-initial-opacity: 1;
+    --nav-initial-offset: 0;
+    --nav-item-initial-opacity: 1;
+    --nav-item-initial-offset: 0;
+  }
+
+  .site-shell__header {
+    transition: none !important;
+    pointer-events: auto !important;
+  }
+
+  .site-shell__brand,
+  .site-shell__nav-link,
+  .site-shell__social {
+    transition: color 0.2s ease !important;
   }
 }
 

--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -11,6 +11,29 @@ export default function RootLayout({ children }) {
     <html lang="en">
       <body>
         <SiteShell>{children}</SiteShell>
+        <noscript>
+          <style>{`
+            :root {
+              --nav-initial-opacity: 1 !important;
+              --nav-initial-offset: 0 !important;
+              --nav-item-initial-opacity: 1 !important;
+              --nav-item-initial-offset: 0 !important;
+            }
+
+            .site-shell__header {
+              pointer-events: auto !important;
+              opacity: 1 !important;
+              transform: translate(-50%, 0) !important;
+            }
+
+            .site-shell__brand,
+            .site-shell__nav-link,
+            .site-shell__social {
+              opacity: 1 !important;
+              transform: none !important;
+            }
+          `}</style>
+        </noscript>
       </body>
     </html>
   );

--- a/components/SiteShell.jsx
+++ b/components/SiteShell.jsx
@@ -74,6 +74,26 @@ export default function SiteShell({ children }) {
     [activeItem]
   );
   const [status, setStatus] = useState(activeStatus);
+  const [navReady, setNavReady] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const motionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+
+    if (motionQuery.matches) {
+      setNavReady(true);
+      return;
+    }
+
+    let frameId = requestAnimationFrame(() => {
+      setNavReady(true);
+    });
+
+    return () => {
+      cancelAnimationFrame(frameId);
+    };
+  }, []);
 
   useEffect(() => {
     setStatus(activeStatus);
@@ -135,12 +155,34 @@ export default function SiteShell({ children }) {
       <div className={`site-shell${isDetailView ? ' site-shell--detail' : ''}`}>
         <div className="site-shell__container">
           {!isDetailView ? (
-            <header className="site-shell__header">
-              <Link href="/" className="site-shell__brand">
+            <header
+              className="site-shell__header"
+              data-nav-ready={navReady ? 'true' : 'false'}
+              style={
+                navReady
+                  ? undefined
+                  : {
+                      opacity: 'var(--nav-initial-opacity, 0)',
+                      transform: 'translate(-50%, var(--nav-initial-offset, -18px))'
+                    }
+              }
+            >
+              <Link
+                href="/"
+                className="site-shell__brand"
+                style={
+                  navReady
+                    ? undefined
+                    : {
+                        opacity: 'var(--nav-item-initial-opacity, 0)',
+                        transform: 'translateY(var(--nav-item-initial-offset, 8px))'
+                      }
+                }
+              >
                 Jay Winder
               </Link>
               <nav className="site-shell__nav" aria-label="Primary navigation">
-                {MENU_ITEMS.map((item) => {
+                {MENU_ITEMS.map((item, index) => {
                   const isActive = item.id === activeSection;
                   return (
                     <Link
@@ -153,6 +195,16 @@ export default function SiteShell({ children }) {
                       onMouseLeave={handleReset}
                       onFocus={() => handlePreview(item, isActive)}
                       onBlur={handleReset}
+                      style={
+                        navReady
+                          ? {
+                              transitionDelay: `${index * 60}ms`
+                            }
+                          : {
+                              opacity: 'var(--nav-item-initial-opacity, 0)',
+                              transform: 'translateY(var(--nav-item-initial-offset, 12px))'
+                            }
+                      }
                     >
                       {item.label}
                     </Link>
@@ -164,6 +216,14 @@ export default function SiteShell({ children }) {
                 className="site-shell__social"
                 target="_blank"
                 rel="noreferrer noopener"
+                style={
+                  navReady
+                    ? undefined
+                    : {
+                        opacity: 'var(--nav-item-initial-opacity, 0)',
+                        transform: 'translateY(var(--nav-item-initial-offset, 8px))'
+                      }
+                }
               >
                 @itsjaydesu
               </Link>

--- a/components/rich-text-editor.jsx
+++ b/components/rich-text-editor.jsx
@@ -6,7 +6,7 @@ import StarterKit from '@tiptap/starter-kit';
 import Image from '@tiptap/extension-image';
 import Link from '@tiptap/extension-link';
 import Placeholder from '@tiptap/extension-placeholder';
-import TextStyle from '@tiptap/extension-text-style';
+import { TextStyle } from '@tiptap/extension-text-style';
 import Color from '@tiptap/extension-color';
 import Highlight from '@tiptap/extension-highlight';
 import FileHandler from '@tiptap/extension-file-handler';

--- a/content/site-text.json
+++ b/content/site-text.json
@@ -1,0 +1,29 @@
+{
+  "brand": "Jay Winder",
+  "primaryMenu": [
+    {
+      "id": "about",
+      "label": "About",
+      "route": "/about",
+      "description": "Jay Winder curates lucid audiovisual experiments, shaping hypnotic interfaces that oscillate between nostalgia and the hyperreal."
+    },
+    {
+      "id": "projects",
+      "label": "Projects",
+      "route": "/projects",
+      "description": "Highlights include kinetic WebGL fields, performance-driven installations, and tactile controls for curious collaborators."
+    },
+    {
+      "id": "words",
+      "label": "Words",
+      "route": "/words",
+      "description": "Dispatches chart process notes, essays on spatial computing, and glossaries for future signal-bearers."
+    },
+    {
+      "id": "sounds",
+      "label": "Sounds",
+      "route": "/sounds",
+      "description": "A rotating archive of ambient loops, chromatic drones, and responsive audio sketches tuned for late-night wanderers."
+    }
+  ]
+}

--- a/lib/mediaIndex.js
+++ b/lib/mediaIndex.js
@@ -1,0 +1,44 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+const FILE_PATH = path.join(process.cwd(), 'content', 'media-index.json');
+
+async function ensureFile() {
+  try {
+    await fs.access(FILE_PATH);
+  } catch (error) {
+    if (error?.code !== 'ENOENT') throw error;
+    await fs.mkdir(path.dirname(FILE_PATH), { recursive: true });
+    await fs.writeFile(FILE_PATH, `${JSON.stringify({ files: [] }, null, 2)}\n`, 'utf8');
+  }
+}
+
+export async function readMediaIndex() {
+  await ensureFile();
+  const raw = await fs.readFile(FILE_PATH, 'utf8');
+  const parsed = JSON.parse(raw);
+  const files = Array.isArray(parsed?.files) ? parsed.files : [];
+  return { files };
+}
+
+export async function appendMediaFile(file) {
+  const { files } = await readMediaIndex();
+  const filtered = files.filter((f) => f.pathname !== file.pathname);
+  filtered.unshift({ ...file, createdAt: file.createdAt || new Date().toISOString() });
+  await fs.writeFile(FILE_PATH, `${JSON.stringify({ files: filtered }, null, 2)}\n`, 'utf8');
+  return { files: filtered };
+}
+
+export async function updateMediaFile(pathname, patch) {
+  const { files } = await readMediaIndex();
+  const next = files.map((f) => (f.pathname === pathname ? { ...f, ...patch } : f));
+  await fs.writeFile(FILE_PATH, `${JSON.stringify({ files: next }, null, 2)}\n`, 'utf8');
+  return next.find((f) => f.pathname === pathname) || null;
+}
+
+export async function removeMediaFile(pathname) {
+  const { files } = await readMediaIndex();
+  const next = files.filter((f) => f.pathname !== pathname);
+  await fs.writeFile(FILE_PATH, `${JSON.stringify({ files: next }, null, 2)}\n`, 'utf8');
+  return { removed: next.length !== files.length };
+}

--- a/lib/siteText.js
+++ b/lib/siteText.js
@@ -1,0 +1,54 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { SITE_TEXT_DEFAULTS as DEFAULTS } from './siteTextDefaults';
+
+const FILE_PATH = path.join(process.cwd(), 'content', 'site-text.json');
+
+// defaults now sourced from shared client-safe module
+
+async function ensureFile() {
+  try {
+    await fs.access(FILE_PATH);
+  } catch (error) {
+    if (error?.code !== 'ENOENT') throw error;
+    await fs.mkdir(path.dirname(FILE_PATH), { recursive: true });
+    await fs.writeFile(FILE_PATH, `${JSON.stringify(DEFAULTS, null, 2)}\n`, 'utf8');
+  }
+}
+
+export async function readSiteText() {
+  await ensureFile();
+  try {
+    const raw = await fs.readFile(FILE_PATH, 'utf8');
+    const parsed = JSON.parse(raw);
+    // Defensive merge with defaults
+    const brand = typeof parsed.brand === 'string' && parsed.brand.trim() ? parsed.brand : DEFAULTS.brand;
+    const primaryMenu = Array.isArray(parsed.primaryMenu) && parsed.primaryMenu.length
+      ? parsed.primaryMenu
+      : DEFAULTS.primaryMenu;
+    return { brand, primaryMenu };
+  } catch (error) {
+    if (error?.code === 'ENOENT') return DEFAULTS;
+    throw error;
+  }
+}
+
+export async function writeSiteText(payload) {
+  const brand = typeof payload?.brand === 'string' && payload.brand.trim() ? payload.brand.trim() : DEFAULTS.brand;
+  const items = Array.isArray(payload?.primaryMenu) ? payload.primaryMenu : [];
+  const primaryMenu = items
+    .map((item, idx) => ({
+      id: String(item?.id ?? idx),
+      label: String(item?.label ?? '').trim() || `Item ${idx + 1}`,
+      route: String(item?.route ?? '').trim() || DEFAULTS.primaryMenu[idx]?.route || '/',
+      description: String(item?.description ?? '').trim() || ''
+    }))
+    .filter((i) => !!i.route);
+
+  const data = { brand, primaryMenu };
+  await fs.mkdir(path.dirname(FILE_PATH), { recursive: true });
+  await fs.writeFile(FILE_PATH, `${JSON.stringify(data, null, 2)}\n`, 'utf8');
+  return data;
+}
+
+// No client-defaults re-export here; import from lib/siteTextDefaults in client code

--- a/lib/siteTextDefaults.js
+++ b/lib/siteTextDefaults.js
@@ -1,0 +1,33 @@
+export const SITE_TEXT_DEFAULTS = {
+  brand: 'Jay Winder',
+  primaryMenu: [
+    {
+      id: 'about',
+      label: 'About',
+      route: '/about',
+      description:
+        'Jay Winder curates lucid audiovisual experiments, shaping hypnotic interfaces that oscillate between nostalgia and the hyperreal.'
+    },
+    {
+      id: 'projects',
+      label: 'Projects',
+      route: '/projects',
+      description:
+        'Highlights include kinetic WebGL fields, performance-driven installations, and tactile controls for curious collaborators.'
+    },
+    {
+      id: 'words',
+      label: 'Words',
+      route: '/words',
+      description:
+        'Dispatches chart process notes, essays on spatial computing, and glossaries for future signal-bearers.'
+    },
+    {
+      id: 'sounds',
+      label: 'Sounds',
+      route: '/sounds',
+      description:
+        'A rotating archive of ambient loops, chromatic drones, and responsive audio sketches tuned for late-night wanderers.'
+    }
+  ]
+};


### PR DESCRIPTION
## Summary
- add dedicated media library UI tied to new media index
- allow editing site-wide text and field settings within admin
- enhance main editor with cover images, status control, and duplication workflows

## Testing
- pnpm run lint
- pnpm run build

_Droid-assisted_